### PR TITLE
chore: refactorized editors to a separate customHook

### DIFF
--- a/src/react-ui/hooks/useEditors.ts
+++ b/src/react-ui/hooks/useEditors.ts
@@ -1,0 +1,42 @@
+import { authService } from "@/modules/auth/application/auth.service";
+import { createAuthRepository } from "@/modules/auth/infrastructure/auth.repository";
+import { mapService } from "@/modules/map/application/map.service";
+import { createMapRepository } from "@/modules/map/infrastructure/map.repository";
+import useSWR from "swr";
+import { useAuth } from "./useAuth";
+
+export function useEditors() {
+    const { accessToken, setAccessToken } = useAuth();
+
+    const { data: editors, error: editorsError, isLoading: editorsLoading, mutate: mutateEditors } = useSWR(
+        accessToken ? ['editors', accessToken] : null,
+        async () => {
+            if (accessToken) {
+                const mapServiceImpl = mapService(createMapRepository());
+                const fetchedEditors = await mapServiceImpl.getEditors(accessToken);
+                return fetchedEditors;
+            }
+
+        },
+        {
+            onErrorRetry: async (error, key, config, revalidate, { retryCount }) => {
+                if (error.response?.status === 403) {
+                    // Intentar renovar el token
+                    const authServiceImpl = authService(createAuthRepository());
+                    const newToken = await authServiceImpl.getToken();
+                    if (newToken.accessToken) {
+                        setAccessToken(newToken.accessToken);
+                        revalidate({ retryCount: retryCount + 1 });
+                    }
+                }
+            },
+        }
+    );
+
+    return {
+        editors,
+        editorsError,
+        editorsLoading,
+        mutateEditors
+    }
+}

--- a/src/react-ui/hooks/userMapManagement.ts
+++ b/src/react-ui/hooks/userMapManagement.ts
@@ -139,32 +139,6 @@ export function useMapManagement() {
         }
     );
 
-
-    const { data: editors, error: editorsError, isLoading: editorsLoading, mutate: mutateEditors } = useSWR(
-        accessToken ? ['editors', accessToken] : null,
-        async () => {
-            if (accessToken) {
-                const mapServiceImpl = mapService(createMapRepository());
-                const fetchedEditors = await mapServiceImpl.getEditors(accessToken);
-                return fetchedEditors;
-            }
-
-        },
-        {
-            onErrorRetry: async (error, key, config, revalidate, { retryCount }) => {
-                if (error.response?.status === 403) {
-                    // Intentar renovar el token
-                    const authServiceImpl = authService(createAuthRepository());
-                    const newToken = await authServiceImpl.getToken();
-                    if (newToken.accessToken) {
-                        setAccessToken(newToken.accessToken);
-                        revalidate({ retryCount: retryCount + 1 });
-                    }
-                }
-            },
-        }
-    );
-
     return {
         maps,
         hasMap,
@@ -175,9 +149,6 @@ export function useMapManagement() {
         isDeleteMapLoading,
         triggerSelectMap,
         isSelectMapLoading,
-        selectMapError,
-        editors,
-        editorsError,
-        editorsLoading
+        selectMapError
     };
 }

--- a/src/react-ui/views/Map/components/EditersModal.test.tsx
+++ b/src/react-ui/views/Map/components/EditersModal.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import EditersModal from './EditersModal';
 import '@testing-library/jest-dom';
-import { useMapManagement } from '@/react-ui/hooks/userMapManagement';
+import { useEditors } from '@/react-ui/hooks/useEditors';
 
 jest.mock('react-i18next', () => ({
     useTranslation: () => ({
@@ -13,11 +13,15 @@ jest.mock('@/react-ui/hooks/userMapManagement', () => ({
     useMapManagement: jest.fn(),
 }));
 
+jest.mock('@/react-ui/hooks/useEditors', () => ({
+    useEditors: jest.fn(),
+}));
+
 describe('EditersModal Component', () => {
     const mockEmails = ['editor1@example.com', 'editor2@example.com'];
 
     beforeEach(() => {
-        (useMapManagement as jest.Mock).mockReturnValue({
+        (useEditors as jest.Mock).mockReturnValue({
             editors: mockEmails,
             editorsError: false,
             editorsLoading: false

--- a/src/react-ui/views/Map/components/EditersModal.tsx
+++ b/src/react-ui/views/Map/components/EditersModal.tsx
@@ -1,7 +1,7 @@
 
 import { Button } from "@/react-ui/components/button"
 import { Card, CardContent, CardFooter } from "@/react-ui/components/card"
-import { useMapManagement } from "@/react-ui/hooks/userMapManagement"
+import { useEditors } from "@/react-ui/hooks/useEditors"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -9,7 +9,7 @@ function EditersModal() {
 
     const [newEditor, setNewEditor] = useState("")
     const { t } = useTranslation();
-    const { editors, editorsError, editorsLoading } = useMapManagement();
+    const { editors, editorsError, editorsLoading } = useEditors();
 
     if (editorsLoading) {
         return (

--- a/src/react-ui/views/Map/components/Hamburger.test.tsx
+++ b/src/react-ui/views/Map/components/Hamburger.test.tsx
@@ -30,7 +30,14 @@ jest.mock('@/react-ui/hooks/userMapManagement', () => {
             isDeleteMapLoading: false,
             triggerSelectMap: jest.fn(),
             isSelectMapLoading: false,
-            selectMapError: false,
+            selectMapError: false
+        }),
+    };
+});
+
+jest.mock('@/react-ui/hooks/useEditors', () => {
+    return {
+        useEditors: () => ({
             editors: ['testEditor'],
             editorsError: false,
             editorsLoading: false

--- a/src/react-ui/views/Map/index.test.tsx
+++ b/src/react-ui/views/Map/index.test.tsx
@@ -10,6 +10,10 @@ jest.mock('@/react-ui/hooks/userMapManagement', () => ({
     useMapManagement: jest.fn(),
 }));
 
+jest.mock('@/react-ui/hooks/useEditors', () => ({
+    useEditors: jest.fn(),
+}));
+
 jest.mock("./components/Map", () => ({
     __esModule: true,
     default: () => (


### PR DESCRIPTION
Movida la logica de obtencion de editores a un hook propio para evitar llamadas innecesarias.